### PR TITLE
re-implemented clear board button w/ new system

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { BOARD_COLS, BOARD_ROWS } from "../lib/constants/board-constants.ts";
 import RandomizeButton from "./ui-components/randomize-button.tsx";
+import ClearBoardButton from "./ui-components/clear-board-button.tsx";
 import PieceContainer from "./piece-container.tsx";
 import { DndContext } from "@dnd-kit/core";
 import GameBoard from "./game-board.tsx";
@@ -18,7 +19,6 @@ export default function Board() {
   );
 
   // here's where we keep track of which pieces are on the board
-  // TODO: actually use it
   const [pieceStatus, setPieceStatus] = useState<PieceStatusMap>(() =>
     Object.fromEntries(
       ALL_PIECE_IDS.map(id => [id, { isOnBoard: false, orientation: { rotation: 0, flip: 0 }, position: null }])
@@ -40,7 +40,10 @@ export default function Board() {
 
   return (
     <DndContext onDragStart={onDragStart} onDragMove={onDragMove} onDragEnd={onDragEnd}>
-      <RandomizeButton setBoard={setCurrentBoard} />
+      <div className="flex gap-x-4">
+        <RandomizeButton setBoard={setCurrentBoard} />
+        <ClearBoardButton setBoard={setCurrentBoard} setPieceStatus={setPieceStatus}/>
+      </div>
       <GameBoard currentBoard={currentBoard} highlightedCells={highlightedCells} />
 
       <PieceContainer pieceStatus={pieceStatus} />

--- a/src/components/ui-components/clear-board-button.tsx
+++ b/src/components/ui-components/clear-board-button.tsx
@@ -1,0 +1,44 @@
+// for testing: clears the board entirely
+
+import type { Dispatch, SetStateAction } from "react";
+import { BOARD_COLS, BOARD_ROWS } from "../../lib/constants/board-constants";
+import type { BoardType } from "../../types/puzzle-types";
+import type { OrientationType, PieceState, PieceStatusMap } from "../../types/puzzle-types";
+
+export default function ClearBoardButton({ 
+    setBoard,
+    setPieceStatus 
+}: { 
+    setBoard: Dispatch<SetStateAction<BoardType>>;
+    setPieceStatus: Dispatch<SetStateAction<PieceStatusMap>>;
+}) {
+  const clearBoard = () => {
+    setBoard(() =>
+        Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(0))
+    );
+
+    setPieceStatus(prev =>
+        Object.fromEntries(
+            Object.keys(prev).map(id => {
+                const baseOrientation: OrientationType = {rotation: 0, flip: 0}
+                const newPieceState: PieceState = {
+                    isOnBoard: false,
+                    orientation: baseOrientation,
+                    position: null
+                };
+                return [+id, newPieceState];
+            })
+        )
+    );
+  };
+
+  return (
+    <button
+      onClick={clearBoard}
+      className="mb-2 px-4 py-2 text-lg font-header bg-emerald-400 text-white rounded 
+      hover:bg-emerald-300 cursor-pointer"
+    >
+      Clear Board
+    </button>
+  );
+}

--- a/src/types/puzzle-types.ts
+++ b/src/types/puzzle-types.ts
@@ -25,7 +25,7 @@ export type PuzzleData = {
 
 // we can rotate it 4 times or we can flip it!
 // beats manually keeping track of variations
-export type OrientationType = { rotation: 0 | 1 | 2 | 3; flip: 0 | 1 };
+export type OrientationType = { rotation: 0 | 1 | 2 | 3, flip: 0 | 1 };
 
 // this is how we keep track of what pieces are on the board
 export type PieceState = {


### PR DESCRIPTION
brought this over, super straightforward. clicking the button = board (and pieceStatusMap) resets

working on bringing rotate and flip into the UI now. will keep you updated.