### PR TITLE
selected piece refactor

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -35,6 +35,9 @@ export default function Board() {
     Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(false))
   );
 
+  // for selected pieces
+  const [selectedPieceId, setSelectedPieceId] = useState<number | null>(null);
+
   // daily puzzle state
   const [dailyPuzzle, setDailyPuzzle] = useState<PuzzleData | null>(null);
   const [puzzleLoaded, setPuzzleLoaded] = useState(false);
@@ -47,12 +50,14 @@ export default function Board() {
     setCurrentBoard,
     pieceStatus,
     setPieceStatus,
-    setIsDragging
+    setIsDragging,
+    selectedPieceId,
+    setSelectedPieceId
   });
 
-  const { handlePieceSelect, handleDeselectAll } = useSelectionHandlers({
-    pieceStatus,
-    setPieceStatus
+  const { selectPiece, deselectAll, isSelected } = useSelectionHandlers({
+    selectedPieceId,
+    setSelectedPieceId
   });
 
   const { startDailyPuzzle, resetToTodaysPuzzle } = useDailyPuzzle({
@@ -77,7 +82,7 @@ export default function Board() {
       const dataId = target.closest("[data-id]")?.getAttribute("data-id") || "";
 
       if (!dataId.includes("piece-")) {
-        handleDeselectAll();
+        deselectAll();
       }
     };
 
@@ -85,7 +90,7 @@ export default function Board() {
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [handleDeselectAll]);
+  }, [deselectAll]);
 
   return (
     <DndContext onDragStart={onDragStart} onDragMove={onDragMove} onDragEnd={onDragEnd}>
@@ -115,7 +120,8 @@ export default function Board() {
             isDragging={isDragging}
             pieceStatus={pieceStatus}
             setPieceStatus={setPieceStatus}
-            onPieceSelect={handlePieceSelect}
+            selectedPieceId={selectedPieceId}
+            onPieceSelect={selectPiece}
           />
         </div>
       </div>

--- a/src/components/piece-container.tsx
+++ b/src/components/piece-container.tsx
@@ -14,15 +14,18 @@ import { Piece } from "./piece";
 export default function PieceContainer({
   pieceStatus,
   setPieceStatus,
+  selectedPieceId,
   onPieceSelect,
   isDragging
 }: {
   pieceStatus: PieceStatusMap;
   setPieceStatus: React.Dispatch<React.SetStateAction<PieceStatusMap>>;
-  onPieceSelect?: (pieceId: number) => void;
+  selectedPieceId: number | null;
+  onPieceSelect: (pieceId: number) => void;
   isDragging: boolean;
 }) {
   const { rotateSelectedClockwise, flipSelectedHorizontally, rotateSelectedCounterclockwise } = usePieceManipulation({
+    selectedPieceId,
     pieceStatus,
     setPieceStatus
   });
@@ -32,7 +35,8 @@ export default function PieceContainer({
       {Object.entries(ALL_PIECES).map(([id, piece]) => {
         const pieceId = +id;
         const pieceState = pieceStatus[pieceId];
-        const showSelectionUi = pieceState.isSelected && !isDragging;
+        const isSelected = (selectedPieceId === pieceId);
+        const showSelectionUi = isSelected && !isDragging;
 
         const currentOrientation = pieceState.orientation;
         const { width, height } = getBoundingBox(currentOrientation);
@@ -40,7 +44,7 @@ export default function PieceContainer({
         if (pieceState.isOnBoard) return null;
 
         return (
-          <div className="relative" data-id={`piece-${pieceId}`}>
+          <div className="relative" key={`piece-${pieceId}`}>
             {showSelectionUi && (
               <div className="absolute z-50 -translate-y-12 flex gap-2">
                 {!ALL_PIECES[pieceId].disableRotation && (
@@ -48,7 +52,11 @@ export default function PieceContainer({
                     className="
                   p-2 bg-primary rounded-md text-background hover:scale-105
               hover:bg-white cursor-pointer"
-                    onClick={rotateSelectedCounterclockwise}
+                    onMouseDown={e => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      rotateSelectedCounterclockwise();
+                    }}
                   >
                     <FaArrowRotateLeft />
                   </button>
@@ -58,8 +66,9 @@ export default function PieceContainer({
                     className="
                   p-2 bg-primary rounded-md text-background hover:scale-105
               hover:bg-white cursor-pointer"
-                    onClick={e => {
+                    onMouseDown={e => {
                       e.stopPropagation();
+                      e.preventDefault();
                       flipSelectedHorizontally();
                     }}
                   >
@@ -71,7 +80,11 @@ export default function PieceContainer({
                     className="
                   p-2 bg-primary rounded-md text-background hover:scale-105
               hover:bg-white cursor-pointer"
-                    onClick={rotateSelectedClockwise}
+                    onMouseDown={e => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      rotateSelectedClockwise();
+                    }}
                   >
                     <FaArrowRotateRight />
                   </button>
@@ -87,14 +100,14 @@ export default function PieceContainer({
                 }}
                 onMouseDown={e => {
                   e.stopPropagation();
-                  onPieceSelect?.(pieceId);
+                  onPieceSelect(pieceId);
                 }}
               >
                 <Piece
                   base={currentOrientation}
                   anchor={[0, 0]} // top-left anchor for layout
                   color={piece.color}
-                  isSelected={pieceState.isSelected}
+                  isSelected={isSelected}
                   isDragging={isDragging}
                 />
               </div>

--- a/src/hooks/drag-handlers.tsx
+++ b/src/hooks/drag-handlers.tsx
@@ -11,7 +11,9 @@ export function useDragHandlers({
   setHighlightedCells,
   pieceStatus,
   setPieceStatus,
-  setIsDragging
+  setIsDragging,
+  selectedPieceId,
+  setSelectedPieceId
 }: {
   currentBoard: BoardType;
   setCurrentBoard: React.Dispatch<React.SetStateAction<BoardType>>;
@@ -19,6 +21,8 @@ export function useDragHandlers({
   pieceStatus: PieceStatusMap;
   setPieceStatus: React.Dispatch<React.SetStateAction<PieceStatusMap>>;
   setIsDragging: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedPieceId: number | null;
+  setSelectedPieceId: React.Dispatch<React.SetStateAction<number | null>>;
 }) {
   // where the mouse currently is
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
@@ -135,7 +139,6 @@ export function useDragHandlers({
       // update the piece placement metadata
       const newPieceState: PieceState = {
         isOnBoard: true,
-        isSelected: false,
         orientation: orientation,
         position: { row: rowIndex, col: colIndex }
       };
@@ -160,6 +163,7 @@ export function useDragHandlers({
     dragPosition,
     dragOffset,
     currentBoard,
+    selectedPieceId,
     setCurrentBoard,
     onDragStart,
     onDragMove,

--- a/src/hooks/piece-selection-handlers.tsx
+++ b/src/hooks/piece-selection-handlers.tsx
@@ -1,41 +1,57 @@
 import type { PieceState, PieceStatusMap } from "../types/puzzle-types";
 
 export function useSelectionHandlers({
-  // pieceStatus,
-  setPieceStatus
+  selectedPieceId,
+  setSelectedPieceId
 }: {
-  pieceStatus?: PieceStatusMap;
-  setPieceStatus: React.Dispatch<React.SetStateAction<PieceStatusMap>>;
+  selectedPieceId: number | null;
+  setSelectedPieceId: React.Dispatch<React.SetStateAction<number | null>>;
 }) {
-  function handlePieceSelect(pieceId: number) {
-    setPieceStatus(prev => {
-      return Object.fromEntries(
-        Object.entries(prev).map(([id, state]) => [
-          +id,
-          +id === pieceId ? { ...state, isSelected: true } : { ...state, isSelected: false }
-        ])
-      );
-    });
+
+  function selectPiece(pieceId: number) {
+    setSelectedPieceId(pieceId)
   }
 
-  function handleDeselectAll() {
-    setPieceStatus(prev => {
-      const newStatus: PieceStatusMap = {};
-
-      Object.entries(prev).forEach(([id, state]) => {
-        const newPieceState: PieceState = {
-          ...state,
-          isSelected: false
-        };
-        newStatus[+id] = newPieceState;
-      });
-
-      return newStatus;
-    });
+  function deselectAll() {
+    setSelectedPieceId(null);
   }
+
+  function isSelected(pieceId: number) {
+    return selectedPieceId === pieceId;
+  }
+
+  // DEPRECATED -- previous implementation
+
+  // function handlePieceSelect(pieceId: number) {
+  //   setPieceStatus(prev => {
+  //     return Object.fromEntries(
+  //       Object.entries(prev).map(([id, state]) => [
+  //         +id,
+  //         +id === pieceId ? { ...state, isSelected: true } : { ...state, isSelected: false }
+  //       ])
+  //     );
+  //   });
+  // }
+
+  // function handleDeselectAll() {
+  //   setPieceStatus(prev => {
+  //     const newStatus: PieceStatusMap = {};
+
+  //     Object.entries(prev).forEach(([id, state]) => {
+  //       const newPieceState: PieceState = {
+  //         ...state,
+  //         isSelected: false
+  //       };
+  //       newStatus[+id] = newPieceState;
+  //     });
+
+  //     return newStatus;
+  //   });
+  // }
 
   return {
-    handlePieceSelect,
-    handleDeselectAll
+    selectPiece,
+    deselectAll,
+    isSelected
   };
 }

--- a/src/hooks/rotate-and-flip-handlers.tsx
+++ b/src/hooks/rotate-and-flip-handlers.tsx
@@ -2,22 +2,22 @@ import type { Coordinate, PieceStatusMap } from "../types/puzzle-types";
 import { rotateClockwise, rotateCounterclockwise, flipHorizontally, flipVertically } from "../lib/ui-helpers/get-oriented-coords";
 
 export function usePieceManipulation({ 
+    selectedPieceId,
     pieceStatus, 
     setPieceStatus 
 }: { 
+    selectedPieceId: number | null;
     pieceStatus: PieceStatusMap;
     setPieceStatus: React.Dispatch<React.SetStateAction<PieceStatusMap>>;
 }) {
 
-    const getSelectedPieceId = () => {
-        return Object.entries(pieceStatus).find(([, state]) => state.isSelected)?.[0];
-    }
-
     function transformSelectedPiece(transformFn: (coords: Coordinate[]) => Coordinate[]) {
-        const selectedPieceId = getSelectedPieceId();
-        if (!selectedPieceId) return;
+        if (selectedPieceId === null) {
+            console.log(selectedPieceId, "no transform because null")
+            return;
+        }
 
-        const pieceId = +selectedPieceId;
+        const pieceId = selectedPieceId;
         const currentOrientation = pieceStatus[pieceId].orientation;
         const newOrientation = transformFn(currentOrientation);
 

--- a/src/types/puzzle-types.ts
+++ b/src/types/puzzle-types.ts
@@ -28,7 +28,6 @@ export type PuzzleData = {
 // this is how we keep track of what pieces are on the board
 export type PieceState = {
   isOnBoard: boolean;
-  isSelected: boolean;
   orientation: Coordinate[];
   position: { row: number; col: number } | null;
 };


### PR DESCRIPTION
refactored select piece. 

tldr:
we are now using [selectedPieceId, setSelectedPieceId], and pushing everything down from the Board(). individual piece state (tracked in the pieceStatusMap) no longer tracks the selected piece.

everything (rendering, rotate/flipping, etc) has been updated to maintain functionality.