### PR TITLE
fix build errors for select refactor

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -55,7 +55,7 @@ export default function Board() {
     setSelectedPieceId
   });
 
-  const { selectPiece, deselectAll, isSelected } = useSelectionHandlers({
+  const { selectPiece, deselectAll } = useSelectionHandlers({
     selectedPieceId,
     setSelectedPieceId
   });

--- a/src/components/ui-components/clear-board-button.tsx
+++ b/src/components/ui-components/clear-board-button.tsx
@@ -22,7 +22,6 @@ export default function ClearBoardButton({
           const baseOrientation: Coordinate[] = ALL_PIECES[+id].base;
           const newPieceState: PieceState = {
             isOnBoard: false,
-            isSelected: false,
             orientation: baseOrientation,
             position: null
           };

--- a/src/hooks/daily-puzzle-handlers.tsx
+++ b/src/hooks/daily-puzzle-handlers.tsx
@@ -72,7 +72,6 @@ export function useDailyPuzzle({
       if (pieceData) {
         const newPieceState: PieceState = {
           isOnBoard: true,
-          isSelected: false,
           orientation: pieceData.orientation,
           position: pieceData.position
         };
@@ -84,7 +83,6 @@ export function useDailyPuzzle({
     puzzle.removablePieces.forEach(pieceId => {
       const newPieceState: PieceState = {
         isOnBoard: false,
-        isSelected: false,
         orientation: ALL_PIECES[pieceId].base,
         position: null
       };
@@ -108,7 +106,6 @@ export function useDailyPuzzle({
         if (pieceData) {
           const newPieceState: PieceState = {
             isOnBoard: true,
-            isSelected: false,
             orientation: pieceData.orientation,
             position: pieceData.position
           };
@@ -120,7 +117,6 @@ export function useDailyPuzzle({
       dailyPuzzle.removablePieces.forEach(pieceId => {
         const newPieceState: PieceState = {
           isOnBoard: false,
-          isSelected: false,
           orientation: ALL_PIECES[pieceId].base,
           position: null
         };

--- a/src/hooks/drag-handlers.tsx
+++ b/src/hooks/drag-handlers.tsx
@@ -147,7 +147,7 @@ export function useDragHandlers({
         ...prev,
         [pieceId]: newPieceState
       }));
-
+      setSelectedPieceId(null);
       setCurrentBoard(updatedBoard);
     }
 

--- a/src/hooks/piece-selection-handlers.tsx
+++ b/src/hooks/piece-selection-handlers.tsx
@@ -1,5 +1,3 @@
-import type { PieceState, PieceStatusMap } from "../types/puzzle-types";
-
 export function useSelectionHandlers({
   selectedPieceId,
   setSelectedPieceId


### PR DESCRIPTION
fixed build errors (as shown on vercel) -> tldr: some unused variables + had forgotten to remove pieceState.isSelected from the puzzle generation helpers.