### PR TITLE
Wuyirenn/ui1

### DIFF
--- a/src/components/drag-and-drop/draggable-piece.tsx
+++ b/src/components/drag-and-drop/draggable-piece.tsx
@@ -6,16 +6,19 @@ import { CSS } from "@dnd-kit/utilities";
 export function DraggablePiece({ 
   id, 
   pieceId, 
-  children 
+  children,
+  cellSize
 }: { 
   id: string; 
   pieceId: number; 
-  children: React.ReactNode 
+  children: React.ReactNode ;
+  cellSize: number;
 }) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id,
     data: {
-      pieceId
+      pieceId,
+      cellSize
     }
   });
 

--- a/src/components/drag-and-drop/droppable-board.tsx
+++ b/src/components/drag-and-drop/droppable-board.tsx
@@ -10,8 +10,8 @@ type DroppableBoardProps = {
 };
 
 export function DroppableBoard({ id, children, cellSize }: DroppableBoardProps) {
-  const { setNodeRef, isOver } = useDroppable({ 
-    id ,
+  const { setNodeRef, isOver } = useDroppable({
+    id,
     data: {
       type: "board",
       cellSize
@@ -22,7 +22,7 @@ export function DroppableBoard({ id, children, cellSize }: DroppableBoardProps) 
     <div
       ref={setNodeRef}
       data-id={id}
-      className={`${isOver ? "bg-transparent" : "bg-transparent"} rounded-lg p-2 border-2 border-white pointer-events-auto`}
+      className={`${isOver ? "bg-transparent" : "bg-transparent"} rounded-lg ring-2 ring-white pointer-events-auto`}
     >
       {children}
     </div>

--- a/src/components/drag-and-drop/droppable-board.tsx
+++ b/src/components/drag-and-drop/droppable-board.tsx
@@ -6,13 +6,15 @@ import React from "react";
 type DroppableBoardProps = {
   id: string;
   children: React.ReactNode;
+  cellSize: number;
 };
 
-export function DroppableBoard({ id, children }: DroppableBoardProps) {
+export function DroppableBoard({ id, children, cellSize }: DroppableBoardProps) {
   const { setNodeRef, isOver } = useDroppable({ 
     id ,
     data: {
-      type: "board"
+      type: "board",
+      cellSize
     }
   });
 

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -7,6 +7,8 @@ import { DroppableBoard } from "./drag-and-drop/droppable-board";
 import { DraggablePiece } from "./drag-and-drop/draggable-piece";
 import { getBoundingBox } from "../lib/ui-helpers/get-bounding-box";
 import { Piece } from "./piece";
+import { useEffect, useRef, useState } from "react";
+import { BOARD_COLS, BOARD_ROWS } from "../lib/constants/board-constants";
 
 export default function GameBoard({
   currentBoard,
@@ -35,10 +37,28 @@ export default function GameBoard({
         }))
     : [];
 
-  const borderOffset = Math.max(1, Math.floor(cellSize * 0.15));
+  const boardRef = useRef<HTMLDivElement | null>(null);
+  const [boardSize, setBoardSize] = useState({ width: 0, height: 0 });
+
+  // measure the current board size responsively
+  useEffect(() => {
+    if (!boardRef.current) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        const { width, height } = entry.contentRect;
+        setBoardSize({ width, height });
+      }
+    });
+
+    observer.observe(boardRef.current);
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
-    <div className="relative">
+    <div ref={boardRef} className="relative">
       <DroppableBoard id="board" cellSize={cellSize}>
         <div className="grid grid-rows-5 grid-cols-11 w-fit">
           {currentBoard.map((row, rowIndex) =>
@@ -83,8 +103,8 @@ export default function GameBoard({
               isSelected ? "z-30" : "z-20"
             }`}
             style={{
-              top: state.position!.row * cellSize + borderOffset,
-              left: state.position!.col * cellSize + borderOffset
+              top: (boardSize.height / BOARD_ROWS) * state.position!.row,
+              left: (boardSize.width / BOARD_COLS) * state.position!.col
             }}
           >
             <DraggablePiece id={id} pieceId={pieceId} key={id} cellSize={cellSize}>

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -1,6 +1,6 @@
 // this is the 5x11 board you see on the screen
 
-import { CELL_SIZE, DEFAULT_COLOR } from "../lib/constants/ui-constants";
+import { DEFAULT_COLOR } from "../lib/constants/ui-constants";
 import { ALL_PIECES } from "../lib/constants/piece-constants";
 import type { BoardType, PieceStatusMap } from "../types/puzzle-types";
 import { DroppableBoard } from "./drag-and-drop/droppable-board";
@@ -14,7 +14,8 @@ export default function GameBoard({
   pieceStatus,
   selectedPieceId,
   onPieceSelect,
-  isDragging
+  isDragging,
+  cellSize
 }: {
   currentBoard: BoardType;
   highlightedCells: boolean[][];
@@ -22,6 +23,7 @@ export default function GameBoard({
   selectedPieceId: number | null;
   onPieceSelect: (pieceId: number) => void;
   isDragging: boolean;
+  cellSize: number;
 }) {
   const piecesOnBoard = pieceStatus
     ? Object.entries(pieceStatus)
@@ -33,9 +35,11 @@ export default function GameBoard({
         }))
     : [];
 
+  const borderOffset = Math.max(1, Math.floor(cellSize * 0.15));
+
   return (
     <div className="relative">
-      <DroppableBoard id="board">
+      <DroppableBoard id="board" cellSize={cellSize}>
         <div className="grid grid-rows-5 grid-cols-11 w-fit">
           {currentBoard.map((row, rowIndex) =>
             row.map((_, colIndex) => {
@@ -45,8 +49,8 @@ export default function GameBoard({
                 <div
                   key={`${rowIndex}-${colIndex}`}
                   style={{
-                    width: CELL_SIZE,
-                    height: CELL_SIZE
+                    width: cellSize,
+                    height: cellSize
                   }}
                   className={`flex items-center justify-center ${
                     isHighlighted ? "border-2 border-white/15 rounded-sm" : ""
@@ -79,11 +83,11 @@ export default function GameBoard({
               isSelected ? "z-30" : "z-20"
             }`}
             style={{
-              top: state.position!.row * CELL_SIZE + 11,
-              left: state.position!.col * CELL_SIZE + 11
+              top: state.position!.row * cellSize + borderOffset,
+              left: state.position!.col * cellSize + borderOffset
             }}
           >
-            <DraggablePiece id={id} pieceId={pieceId} key={id}>
+            <DraggablePiece id={id} pieceId={pieceId} key={id} cellSize={cellSize}>
               <div
                 className={`relative ${
                   isSelected
@@ -93,8 +97,8 @@ export default function GameBoard({
                     : "pointer-events-auto"
                 } `}
                 style={{
-                  width: width * CELL_SIZE,
-                  height: height * CELL_SIZE
+                  width: width * cellSize,
+                  height: height * cellSize
                 }}
                 onMouseDown={e => {
                   e.stopPropagation();
@@ -107,6 +111,7 @@ export default function GameBoard({
                   color={ALL_PIECES[pieceId].color}
                   isSelected={isSelected}
                   isDragging={isDragging}
+                  cellSize={cellSize}
                 />
               </div>
             </DraggablePiece>

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -11,12 +11,14 @@ import type { BoardType, PieceStatusMap, PuzzleData } from "../types/puzzle-type
 import { useDragHandlers } from "../hooks/drag-handlers.tsx";
 import { useSelectionHandlers } from "../hooks/piece-selection-handlers.tsx";
 import { useDailyPuzzle } from "../hooks/daily-puzzle-handlers.tsx";
+import { useResponsiveCellSize } from "../hooks/useResponsiveCellSize.tsx";
 import PieceContainer from "./piece-container.tsx";
-import { CELL_SIZE } from "../lib/constants/ui-constants.ts";
 import { FaHourglassHalf } from "react-icons/fa6";
 import { useTimer } from "../hooks/use-timer.tsx";
 
 export default function Board() {
+
+  const { cellSize, scaleContainer } = useResponsiveCellSize()
   // this is the actual game board
   const [currentBoard, setCurrentBoard] = useState<BoardType>(() =>
     Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(0))
@@ -54,7 +56,8 @@ export default function Board() {
     setPieceStatus,
     setIsDragging,
     selectedPieceId,
-    setSelectedPieceId
+    setSelectedPieceId,
+    cellSize
   });
 
   const { selectPiece, deselectAll } = useSelectionHandlers({
@@ -119,44 +122,47 @@ export default function Board() {
 
   return (
     <DndContext onDragStart={onDragStart} onDragMove={onDragMove} onDragEnd={onDragEnd}>
-      <div className="flex flex-col w-10/12 h-full justify-items-center items-center p-4 gap-4">
-        <div className="flex justify-between gap-8 items-end" style={{ width: CELL_SIZE * BOARD_COLS }}>
+      <div className="flex flex-col w-full max-w-6xl mx-auto h-full justify-items-center items-center p-2 sm:p-4 gap-2 sm:gap-4 overflow-hidden">
+        <div className="flex flex-col sm:flex-row justify-between gap-4 sm:gap-8 items-center sm:items-end w-full" style={{ maxWidth: cellSize * BOARD_COLS }}>
           <div className="flex flex-col gap-2 items-left text-text">
-            <h1 className="text-4xl font-header font-normal">Color Puzzle Game</h1>
-            <p className="font-body">
+            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-header font-normal text-center sm:text-left">Color Puzzle Game</h1>
+            <p className="font-body text-sm sm:text-base text-center sm:text-left">
               Click pieces to flip and rotate. Drag to fill the whole board. <br />
               Come back daily for a new puzzle!
             </p>
           </div>
           <div className="flex flex-col gap-2 items-center">
-            <div className="text-primary flex items-center gap-1">
+            <div className="ext-primary flex items-center gap-1 text-sm sm:text-base">
               <FaHourglassHalf />
               <p>{getFormattedTime()}</p>
             </div>
 
             {!puzzleLoaded ? (
               <Button onClick={startDailyPuzzle} title="Start Today's Puzzle (R)">
-                Start Today's Puzzle
+                <span className="text-sm sm:text-base">Start Today's Puzzle</span>
               </Button>
             ) : (
               <Button onClick={resetToTodaysPuzzle} title="Reset Puzzle (R)">
-                Reset Puzzle
+                <span className="text-sm sm:text-base">Reset Puzzle</span>
               </Button>
             )}
           </div>
         </div>
 
-        <div className="flex gap-x-8">
-          <GameBoard
-            currentBoard={currentBoard}
-            highlightedCells={highlightedCells}
-            pieceStatus={pieceStatus}
-            selectedPieceId={selectedPieceId}
-            onPieceSelect={selectPiece}
-            isDragging={isDragging}
-          />
+        <div className="flex justify-center w-full p-4" style={{ transform: scaleContainer, transformOrigin: 'center top' }}>
+          <div className="flex gap-x-4 sm:gap-x-8">
+            <GameBoard
+              currentBoard={currentBoard}
+              highlightedCells={highlightedCells}
+              pieceStatus={pieceStatus}
+              selectedPieceId={selectedPieceId}
+              onPieceSelect={selectPiece}
+              isDragging={isDragging}
+              cellSize={cellSize}
+            />
+          </div>
         </div>
-        <div className="pt-8">
+        <div className="pt-4 w-full flex justify-center" style={{ transform: scaleContainer, transformOrigin: 'center top' }}>
           <PieceContainer
             pieceStatus={pieceStatus}
             setPieceStatus={setPieceStatus}
@@ -164,6 +170,7 @@ export default function Board() {
             deselectAll={deselectAll}
             onPieceSelect={selectPiece}
             isDragging={isDragging}
+            cellSize={cellSize}
           />
         </div>
       </div>

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -17,8 +17,7 @@ import { FaHourglassHalf } from "react-icons/fa6";
 import { useTimer } from "../hooks/use-timer.tsx";
 
 export default function Board() {
-
-  const { cellSize, scaleContainer } = useResponsiveCellSize()
+  const { cellSize, scaleContainer } = useResponsiveCellSize();
   // this is the actual game board
   const [currentBoard, setCurrentBoard] = useState<BoardType>(() =>
     Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(0))
@@ -123,16 +122,21 @@ export default function Board() {
   return (
     <DndContext onDragStart={onDragStart} onDragMove={onDragMove} onDragEnd={onDragEnd}>
       <div className="flex flex-col w-full max-w-6xl mx-auto h-full justify-items-center items-center p-2 sm:p-4 gap-2 sm:gap-4 overflow-hidden">
-        <div className="flex flex-col sm:flex-row justify-between gap-4 sm:gap-8 items-center sm:items-end w-full" style={{ maxWidth: cellSize * BOARD_COLS }}>
+        <div
+          className="flex flex-col sm:flex-row justify-between gap-4 sm:gap-8 items-center sm:items-end w-full"
+          style={{ maxWidth: cellSize * BOARD_COLS }}
+        >
           <div className="flex flex-col gap-2 items-left text-text">
-            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-header font-normal text-center sm:text-left">Color Puzzle Game</h1>
+            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-header font-normal text-center sm:text-left">
+              Color Puzzle Game
+            </h1>
             <p className="font-body text-sm sm:text-base text-center sm:text-left">
               Click pieces to flip and rotate. Drag to fill the whole board. <br />
               Come back daily for a new puzzle!
             </p>
           </div>
           <div className="flex flex-col gap-2 items-center">
-            <div className="ext-primary flex items-center gap-1 text-sm sm:text-base text-text">
+            <div className="text-primary flex items-center gap-1 text-sm font-body sm:text-base ">
               <FaHourglassHalf />
               <p>{getFormattedTime()}</p>
             </div>
@@ -149,7 +153,10 @@ export default function Board() {
           </div>
         </div>
 
-        <div className="flex justify-center w-full p-4" style={{ transform: scaleContainer, transformOrigin: 'center top' }}>
+        <div
+          className="flex justify-center w-full p-4"
+          style={{ transform: scaleContainer, transformOrigin: "center top" }}
+        >
           <div className="flex gap-x-4 sm:gap-x-8">
             <GameBoard
               currentBoard={currentBoard}
@@ -162,7 +169,10 @@ export default function Board() {
             />
           </div>
         </div>
-        <div className="pt-4 w-full flex justify-center" style={{ transform: scaleContainer, transformOrigin: 'center top' }}>
+        <div
+          className="pt-4 w-full flex justify-center"
+          style={{ transform: scaleContainer, transformOrigin: "center top" }}
+        >
           <PieceContainer
             pieceStatus={pieceStatus}
             setPieceStatus={setPieceStatus}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -132,7 +132,7 @@ export default function Board() {
             </p>
           </div>
           <div className="flex flex-col gap-2 items-center">
-            <div className="ext-primary flex items-center gap-1 text-sm sm:text-base">
+            <div className="ext-primary flex items-center gap-1 text-sm sm:text-base text-text">
               <FaHourglassHalf />
               <p>{getFormattedTime()}</p>
             </div>

--- a/src/components/piece-container.tsx
+++ b/src/components/piece-container.tsx
@@ -6,7 +6,6 @@ import { FaArrowRotateRight, FaArrowRotateLeft } from "react-icons/fa6";
 import { useDroppable } from "@dnd-kit/core";
 import { usePieceManipulation } from "../hooks/rotate-and-flip-handlers";
 import { ALL_PIECES } from "../lib/constants/piece-constants";
-import { CELL_SIZE } from "../lib/constants/ui-constants";
 import { getBoundingBox } from "../lib/ui-helpers/get-bounding-box";
 import type { PieceStatusMap } from "../types/puzzle-types";
 import { DraggablePiece } from "./drag-and-drop/draggable-piece";
@@ -19,7 +18,8 @@ export default function PieceContainer({
   selectedPieceId,
   deselectAll,
   onPieceSelect,
-  isDragging
+  isDragging,
+  cellSize
 }: {
   pieceStatus: PieceStatusMap;
   setPieceStatus: React.Dispatch<React.SetStateAction<PieceStatusMap>>;
@@ -27,6 +27,7 @@ export default function PieceContainer({
   deselectAll: () => void;
   onPieceSelect: (pieceId: number) => void;
   isDragging: boolean;
+  cellSize: number;
 }) {
   const { setNodeRef } = useDroppable({
     id: "piece-container",
@@ -67,7 +68,7 @@ export default function PieceContainer({
   }, [flipSelectedHorizontally, rotateSelectedClockwise, rotateSelectedCounterclockwise, deselectAll]);
 
   return (
-    <div ref={setNodeRef} className="flex flex-wrap gap-4 p-4">
+    <div ref={setNodeRef} className="flex flex-wrap gap-1 sm:gap-2 md:gap-4 p-1 sm:p-2 md:p-4 max-w-full justify-center">
       {Object.entries(ALL_PIECES).map(([id, piece]) => {
         const pieceId = +id;
         const pieceState = pieceStatus[pieceId];
@@ -81,15 +82,13 @@ export default function PieceContainer({
         return (
           <div className="relative" key={`piece-${pieceId}`}>
             {isSelected && !isDragging && (
-              <div className="absolute z-50 -translate-y-12 flex gap-2">
+              <div className="absolute z-50 -translate-y-8 sm:-translate-y-10 flex gap-1 sm:gap-2">
                 {!ALL_PIECES[pieceId].disableRotation && (
                   <button
                     aria-label="Rotate piece counterclockwise (←)"
                     title="Rotate piece counterclockwise (←)"
                     type="button"
-                    className="
-                  p-2 bg-primary rounded-md text-background hover:scale-105
-              hover:bg-white cursor-pointer"
+                    className="p-1 sm:p-2 bg-primary rounded-md text-background hover:scale-105 hover:bg-white cursor-pointer text-xs sm:text-sm"
                     onMouseDown={e => {
                       e.stopPropagation();
                       e.preventDefault();
@@ -104,9 +103,7 @@ export default function PieceContainer({
                     type="button"
                     aria-label="Flip piece horizontally (↓ or F)"
                     title="Flip piece horizontally (↓ or F)"
-                    className="
-                  p-2 bg-primary rounded-md text-background hover:scale-105
-              hover:bg-white cursor-pointer"
+                    className="p-1 sm:p-2 bg-primary rounded-md text-background hover:scale-105 hover:bg-white cursor-pointer text-xs sm:text-sm"
                     onMouseDown={e => {
                       e.stopPropagation();
                       e.preventDefault();
@@ -121,9 +118,7 @@ export default function PieceContainer({
                     type="button"
                     aria-label="Rotate piece clockwise (→)"
                     title="Rotate piece clockwise (→)"
-                    className="
-                  p-2 bg-primary rounded-md text-background hover:scale-105
-              hover:bg-white cursor-pointer"
+                    className="p-1 sm:p-2 bg-primary rounded-md text-background hover:scale-105 hover:bg-white cursor-pointer text-xs sm:text-sm"
                     onMouseDown={e => {
                       e.stopPropagation();
                       e.preventDefault();
@@ -135,12 +130,12 @@ export default function PieceContainer({
                 )}
               </div>
             )}
-            <DraggablePiece id={id} pieceId={pieceId} key={id}>
+            <DraggablePiece id={id} pieceId={pieceId} key={id} cellSize={cellSize}>
               <div
                 className="relative"
                 style={{
-                  width: width * CELL_SIZE,
-                  height: height * CELL_SIZE
+                  width: width * cellSize,
+                  height: height * cellSize
                 }}
                 onMouseDown={e => {
                   e.stopPropagation();
@@ -153,6 +148,7 @@ export default function PieceContainer({
                   color={piece.color}
                   isSelected={isSelected}
                   isDragging={isDragging}
+                  cellSize={cellSize}
                 />
               </div>
             </DraggablePiece>

--- a/src/components/piece.tsx
+++ b/src/components/piece.tsx
@@ -1,6 +1,5 @@
 // this is what a piece looks like when it's not yet placed on the board
 
-import { CELL_SIZE } from "../lib/constants/ui-constants";
 import { type Coordinate } from "../types/puzzle-types";
 
 export function Piece({
@@ -8,19 +7,24 @@ export function Piece({
   anchor,
   color,
   isSelected = false,
-  isDragging
+  isDragging,
+  cellSize
 }: {
   base: Coordinate[];
   anchor: [number, number];
   color: string;
   isSelected?: boolean;
   isDragging: boolean;
+  cellSize: number;
 }) {
   // fast lookup for border rendering
   const cellSet = new Set(base.map(([r, c]) => `${r},${c}`));
   const hasCell = (r: number, c: number) => cellSet.has(`${r},${c}`);
 
   const borderColor = (isSelected && !isDragging) ? "rgba(255,255,255,0.2)" : "transparent";
+
+  const cellOffset = Math.max(1, Math.floor(cellSize * 0.015));
+  const totalCellSize = cellSize + (cellOffset * 2);
 
   // this mess is here SIMPLY cause I wanted to make the piece bigger on hover lol
   // 1) bounding box in cell units
@@ -31,10 +35,10 @@ export function Piece({
   const minDc = Math.min(...dcs);
   const maxDc = Math.max(...dcs);
   // 2) wrapper position in px (align to top-left of piece)
-  const groupTop = (anchor[0] + minDr) * CELL_SIZE;
-  const groupLeft = (anchor[1] + minDc) * CELL_SIZE;
-  const groupWidth = (maxDc - minDc + 1) * CELL_SIZE + 2; // +2 to account for your 1px offset borders
-  const groupHeight = (maxDr - minDr + 1) * CELL_SIZE + 2;
+  const groupTop = (anchor[0] + minDr) * cellSize;
+  const groupLeft = (anchor[1] + minDc) * cellSize;
+  const groupWidth = (maxDc - minDc + 1) * cellSize + 2; // +2 to account for your 1px offset borders
+  const groupHeight = (maxDr - minDr + 1) * cellSize + 2;
 
   return (
     <div className="relative">
@@ -42,15 +46,15 @@ export function Piece({
         className="absolute cursor-pointer origin-center transition-transform
          duration-150 ease-out hover:scale-105 z-0"
         style={{
-          top: groupTop - 1,
-          left: groupLeft - 1,
+          top: groupTop - cellOffset,
+          left: groupLeft - cellOffset,
           width: groupWidth,
           height: groupHeight
         }}
       >
         {base.map(([dr, dc], i) => {
-          const top = (anchor[0] + dr) * CELL_SIZE;
-          const left = (anchor[1] + dc) * CELL_SIZE;
+          const top = (anchor[0] + dr) * cellSize;
+          const left = (anchor[1] + dc) * cellSize;
 
           const borderTop = !hasCell(dr - 1, dc) ? `2px solid ${borderColor}` : "none";
           const borderBottom = !hasCell(dr + 1, dc) ? `2px solid ${borderColor}` : "none";
@@ -62,10 +66,10 @@ export function Piece({
               key={i}
               className="absolute flex items-center justify-center"
               style={{
-                top: top - 1,
-                left: left - 1,
-                width: CELL_SIZE + 2,
-                height: CELL_SIZE + 2,
+                top: top - cellOffset,
+                left: left - cellOffset,
+                width: totalCellSize,
+                height: totalCellSize,
                 color: color,
                 borderTop,
                 borderBottom,

--- a/src/hooks/drag-handlers.tsx
+++ b/src/hooks/drag-handlers.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { BOARD_ROWS, BOARD_COLS } from "../lib/constants/board-constants";
-import { CELL_SIZE } from "../lib/constants/ui-constants";
 import { canPlacePiece } from "../lib/ui-helpers/can-place-piece";
 import { removePieceFromBoard } from "../lib/ui-helpers/board-utils";
 import type { BoardType, Coordinate, PieceState, PieceStatusMap } from "../types/puzzle-types";
@@ -14,7 +13,8 @@ export function useDragHandlers({
   setPieceStatus,
   setIsDragging,
   selectedPieceId,
-  setSelectedPieceId
+  setSelectedPieceId,
+  cellSize
 }: {
   currentBoard: BoardType;
   setCurrentBoard: React.Dispatch<React.SetStateAction<BoardType>>;
@@ -24,6 +24,7 @@ export function useDragHandlers({
   setIsDragging: React.Dispatch<React.SetStateAction<boolean>>;
   selectedPieceId: number | null;
   setSelectedPieceId: React.Dispatch<React.SetStateAction<number | null>>;
+  cellSize: number;
 }) {
   // where the mouse currently is
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
@@ -44,8 +45,8 @@ export function useDragHandlers({
 
     // return which cell it lands in
     return {
-      colIndex: Math.floor(relX / CELL_SIZE),
-      rowIndex: Math.floor(relY / CELL_SIZE)
+      colIndex: Math.floor(relX / cellSize),
+      rowIndex: Math.floor(relY / cellSize)
     };
   }
 
@@ -126,8 +127,8 @@ export function useDragHandlers({
     const boardRect = boardEl.getBoundingClientRect();
 
     // how far the mouse is from the MIDDLE of the top-left "cell" of the piece
-    const cellCenterX = CELL_SIZE / 2;
-    const cellCenterY = CELL_SIZE / 2;
+    const cellCenterX = cellSize / 2;
+    const cellCenterY = cellSize / 2;
     const offsetX = mouseEvent.clientX - (pieceRect.left + cellCenterX);
     const offsetY = mouseEvent.clientY - (pieceRect.top + cellCenterY);
 

--- a/src/hooks/useResponsiveCellSize.tsx
+++ b/src/hooks/useResponsiveCellSize.tsx
@@ -1,50 +1,50 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import { BASE_CELL_SIZE, MIN_CELL_SIZE, PADDING_ALLOWANCE } from "../lib/constants/ui-constants";
 import { BOARD_ROWS, BOARD_COLS } from "../lib/constants/board-constants";
 
 export function useResponsiveCellSize() {
-    const [cellSize, setCellSize] = useState(BASE_CELL_SIZE);
-    const [scaleContainer, setScaleContainer] = useState('scale(1)');
+  const [cellSize, setCellSize] = useState(BASE_CELL_SIZE);
+  const [scaleContainer, setScaleContainer] = useState("scale(1)");
 
-    useEffect(() => {
-        const calculateResponsiveSize = () => {
-        const windowWidth = window.innerWidth;
-        const windowHeight = window.innerHeight;
-        
-        // Calculate available space for the board
-        const availableWidth = windowWidth - PADDING_ALLOWANCE;
-        const availableHeight = windowHeight - 300; // Reserve space for header, pieces, etc.
-        
-        // Calculate what cell size would fit based on board dimensions
-        const maxCellSizeByWidth = Math.floor(availableWidth / BOARD_COLS);
-        const maxCellSizeByHeight = Math.floor(availableHeight / BOARD_ROWS);
-        
-        // Use the smaller constraint
-        let newCellSize = Math.min(maxCellSizeByWidth, maxCellSizeByHeight, BASE_CELL_SIZE);
-        
-        // If the calculated cell size is too small, use minimum and scale the container
-        if (newCellSize < MIN_CELL_SIZE) {
-            const scaleFactor = newCellSize / MIN_CELL_SIZE;
-            setCellSize(MIN_CELL_SIZE);
-            setScaleContainer(`scale(${Math.max(scaleFactor, 0.5)})`); // Don't scale below 0.5
-        } else {
-            setCellSize(newCellSize);
-            setScaleContainer('scale(1)');
-        }
-        };
+  useEffect(() => {
+    const calculateResponsiveSize = () => {
+      const windowWidth = window.innerWidth;
+      const windowHeight = window.innerHeight;
 
-        calculateResponsiveSize();
-        
-        const handleResize = () => {
-        calculateResponsiveSize();
-        };
+      // Calculate available space for the board
+      const availableWidth = windowWidth - PADDING_ALLOWANCE;
+      const availableHeight = windowHeight - 300; // Reserve space for header, pieces, etc.
 
-        window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
-    }, []);
+      // Calculate what cell size would fit based on board dimensions
+      const maxCellSizeByWidth = Math.floor(availableWidth / BOARD_COLS);
+      const maxCellSizeByHeight = Math.floor(availableHeight / BOARD_ROWS);
 
-    return {
-        cellSize,
-        scaleContainer
+      // Use the smaller constraint
+      const newCellSize = Math.min(maxCellSizeByWidth, maxCellSizeByHeight, BASE_CELL_SIZE);
+
+      // If the calculated cell size is too small, use minimum and scale the container
+      if (newCellSize < MIN_CELL_SIZE) {
+        const scaleFactor = newCellSize / MIN_CELL_SIZE;
+        setCellSize(MIN_CELL_SIZE);
+        setScaleContainer(`scale(${Math.max(scaleFactor, 0.5)})`); // Don't scale below 0.5
+      } else {
+        setCellSize(newCellSize);
+        setScaleContainer("scale(1)");
+      }
     };
+
+    calculateResponsiveSize();
+
+    const handleResize = () => {
+      calculateResponsiveSize();
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return {
+    cellSize,
+    scaleContainer
+  };
 }

--- a/src/hooks/useResponsiveCellSize.tsx
+++ b/src/hooks/useResponsiveCellSize.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { BASE_CELL_SIZE, MIN_CELL_SIZE, PADDING_ALLOWANCE } from "../lib/constants/ui-constants";
+import { BOARD_ROWS, BOARD_COLS } from "../lib/constants/board-constants";
+
+export function useResponsiveCellSize() {
+    const [cellSize, setCellSize] = useState(BASE_CELL_SIZE);
+    const [scaleContainer, setScaleContainer] = useState('scale(1)');
+
+    useEffect(() => {
+        const calculateResponsiveSize = () => {
+        const windowWidth = window.innerWidth;
+        const windowHeight = window.innerHeight;
+        
+        // Calculate available space for the board
+        const availableWidth = windowWidth - PADDING_ALLOWANCE;
+        const availableHeight = windowHeight - 300; // Reserve space for header, pieces, etc.
+        
+        // Calculate what cell size would fit based on board dimensions
+        const maxCellSizeByWidth = Math.floor(availableWidth / BOARD_COLS);
+        const maxCellSizeByHeight = Math.floor(availableHeight / BOARD_ROWS);
+        
+        // Use the smaller constraint
+        let newCellSize = Math.min(maxCellSizeByWidth, maxCellSizeByHeight, BASE_CELL_SIZE);
+        
+        // If the calculated cell size is too small, use minimum and scale the container
+        if (newCellSize < MIN_CELL_SIZE) {
+            const scaleFactor = newCellSize / MIN_CELL_SIZE;
+            setCellSize(MIN_CELL_SIZE);
+            setScaleContainer(`scale(${Math.max(scaleFactor, 0.5)})`); // Don't scale below 0.5
+        } else {
+            setCellSize(newCellSize);
+            setScaleContainer('scale(1)');
+        }
+        };
+
+        calculateResponsiveSize();
+        
+        const handleResize = () => {
+        calculateResponsiveSize();
+        };
+
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return {
+        cellSize,
+        scaleContainer
+    };
+}

--- a/src/lib/constants/ui-constants.ts
+++ b/src/lib/constants/ui-constants.ts
@@ -2,6 +2,10 @@
 
 export const CELL_SIZE = 64;
 
+export const BASE_CELL_SIZE = 64;
+export const MIN_CELL_SIZE = 32;
+export const PADDING_ALLOWANCE = 32;
+
 // default color if a cell is empty
 export const DEFAULT_COLOR = "#ffffff";
 export const ERROR_COLOR = "#000000";


### PR DESCRIPTION
incomplete -- having trouble drawing pieces in correct position, responsively. need a hand i think, though will sleep on it.

also: 
board, text, containers are responsive now, though may not quite be following best ui practices. 

biggest changes:
created a useResponsiveCellSize handler to scale cellSize and implemented across all components. made adjustments via Tailwind to containers, components, text.

biggest challenge:
something with how the pieces are drawn is not translating well to responsive/smaller pieces and board. can't quite figure out how to place them correctly. it seems like there's fundamental spacing issues with the gaps between piece cells, but the pieces themselves might just be too large as well.
->
it's most noticeable when the screen gets smaller; the pieces are not aligned to the dots that denote the cell centers.

reason why i'm doing this: 
realized the pieceContainer woes are largely tied to its exorbitant and disproportional sizing, though welcome to additional ideas. may still implement free drag and drop in the piece container in future PR, though that's lower priority imo.